### PR TITLE
fix(webhook): filter compose file collection to Renovate-authored commits only

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -173,14 +173,10 @@ impl DeploymentOrchestrator {
             tracing::info!("Ignoring push to non-default branch");
             return Ok(());
         }
-        if !payload.is_renovate_commit(&self.renovate_username, &self.renovate_email)
-        {
-            tracing::info!("Ignoring non-Renovate commit");
-            return Ok(());
-        }
-
-        let modified: Vec<String> =
-            payload.modified_compose_files().into_iter().collect();
+        let modified: Vec<String> = payload
+            .modified_compose_files(&self.renovate_username, &self.renovate_email)
+            .into_iter()
+            .collect();
         if modified.is_empty() {
             tracing::info!("No compose file changes, skipping");
             return Ok(());

--- a/src/container/webhook.rs
+++ b/src/container/webhook.rs
@@ -95,25 +95,31 @@ impl WebhookPayload {
         self.git_ref == format!("refs/heads/{}", self.repository.default_branch)
     }
 
-    /// Check if any commit in this push looks like a Renovate commit.
-    pub fn is_renovate_commit(&self, username: &str, email: &str) -> bool {
-        self.commits.iter().any(|c| {
-            is_renovate_author(
-                c.author.username.as_deref(),
-                &c.author.name,
-                &c.author.email,
-                username,
-                email,
-            )
-        })
-    }
-
-    /// Returns all compose files (*.yaml / *.yml) touched across all commits.
+    /// Returns compose files (*.yaml / *.yml) touched by Renovate-authored commits only.
+    ///
+    /// Filtering by author here (rather than as a separate `is_renovate_commit` guard)
+    /// prevents human commits in a mixed push from being auto-deployed alongside
+    /// legitimate Renovate changes. Returns an empty set when no Renovate commits
+    /// touched compose files, which the caller treats as "nothing to do".
+    ///
     /// Duplicate delivery of the same webhook is safe: the second pass will
     /// find no config diff after the first already wrote and deployed.
-    pub fn modified_compose_files(&self) -> HashSet<String> {
+    pub fn modified_compose_files(
+        &self,
+        username: &str,
+        email: &str,
+    ) -> HashSet<String> {
         self.commits
             .iter()
+            .filter(|c| {
+                is_renovate_author(
+                    c.author.username.as_deref(),
+                    &c.author.name,
+                    &c.author.email,
+                    username,
+                    email,
+                )
+            })
             .flat_map(|c| c.modified.iter().chain(c.added.iter()))
             .filter(|f| f.ends_with(".yaml") || f.ends_with(".yml"))
             .cloned()
@@ -164,8 +170,11 @@ mod tests {
 
         assert_eq!(payload.repository.full_name, "user/my-app");
         assert!(payload.is_default_branch());
-        assert!(payload.is_renovate_commit("renovate", "renovate"));
-        assert!(!payload.modified_compose_files().is_empty());
+        assert!(
+            !payload
+                .modified_compose_files("renovate", "renovate@github.com")
+                .is_empty()
+        );
     }
 
     #[test]


### PR DESCRIPTION
is_renovate_commit used .any() — a single Renovate commit in a mixed push was enough to let modified_compose_files collect changed files from all commits, including human-authored ones. This could trigger auto-deployment of changes that were never reviewed by Renovate.

Merge the author check into modified_compose_files so only commits from the configured Renovate identity contribute to the file set. Remove the now-redundant is_renovate_commit method
