### PR TITLE
fix(routes): spawn manual_deploy and return 202 Accepted

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -114,7 +114,7 @@ impl DeploymentOrchestrator {
     /// deployment semaphore as `handle_webhook` to prevent races.
     pub async fn deploy_service(
         &self,
-        service: &ServiceEntry,
+        service: ServiceEntry,
         image: Option<String>,
     ) -> Result<()> {
         if !self.is_service_allowed(&service.name) {
@@ -127,10 +127,14 @@ impl DeploymentOrchestrator {
             Some(img) => {
                 let image_ref = ImageReference::parse(&img)?;
                 check_tag_policy(&service.name, &image_ref, self.allow_latest)?;
-                let (path, name, image) =
+                let (path, name, img_for_write) =
                     (service.path.clone(), service.name.clone(), img.clone());
                 tokio::task::spawn_blocking(move || {
-                    crate::fs::walk::write_service_image(&path, &name, &image)
+                    crate::fs::walk::write_service_image(
+                        &path,
+                        &name,
+                        &img_for_write,
+                    )
                 })
                 .await
                 .map_err(|e| eyre!("write_service_image task panicked: {e}"))?
@@ -140,12 +144,12 @@ impl DeploymentOrchestrator {
                     image = %img,
                     "Updated compose file with new image for manual deploy"
                 );
-                ServiceEntry { image: img, ..service.clone() }
+                ServiceEntry { image: img, ..service }
             }
             None => {
                 let image_ref = ImageReference::parse(&service.image)?;
                 check_tag_policy(&service.name, &image_ref, self.allow_latest)?;
-                service.clone()
+                service
             }
         };
         let _permit =

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -370,10 +370,9 @@ pub async fn manual_deploy(
         }
     };
 
-    let service_name = req.service.clone();
+    let service_name = service.name.clone();
     tokio::spawn(async move {
-        if let Err(e) = state.orchestrator.deploy_service(&service, req.image).await
-        {
+        if let Err(e) = state.orchestrator.deploy_service(service, req.image).await {
             tracing::error!("Manual deploy of '{service_name}' failed: {e:?}");
         }
     });

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -370,13 +370,15 @@ pub async fn manual_deploy(
         }
     };
 
-    match state.orchestrator.deploy_service(&service, req.image).await {
-        Ok(()) => StatusCode::OK,
-        Err(e) => {
-            tracing::error!("Manual deploy of '{}' failed: {e:?}", req.service);
-            StatusCode::INTERNAL_SERVER_ERROR
+    let service_name = req.service.clone();
+    tokio::spawn(async move {
+        if let Err(e) = state.orchestrator.deploy_service(&service, req.image).await
+        {
+            tracing::error!("Manual deploy of '{service_name}' failed: {e:?}");
         }
-    }
+    });
+
+    StatusCode::ACCEPTED
 }
 
 // ── flag endpoints ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Previously deploy_service was awaited directly in the handler. A client timeout or disconnect would cancel the future mid-pull, leaving the deploy in an unknown state with no log record of the outcome.

Validation (deployments_paused, find_service) stays synchronous. Only the deploy itself is spawned so it runs to completion regardless of connection lifetime. Errors are logged and recorded in history.

