### PR TITLE
feat: introduce DockerExecutor trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,9 +312,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -550,9 +550,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "equivalent"
@@ -775,9 +775,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1031,9 +1031,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1604,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -1909,9 +1909,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3035,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3046,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/container.rs
+++ b/src/container.rs
@@ -3,7 +3,7 @@ pub mod github;
 pub mod image;
 pub mod webhook;
 
-use docker::DockerClient;
+use docker::{DockerClient, DockerExecutor};
 use github::GitHubClient;
 use image::ImageReference;
 
@@ -59,8 +59,8 @@ pub struct Deployment {
 ///
 /// Concurrent webhook deliveries are serialized by an internal semaphore —
 /// the HTTP response is immediate, but the actual deploy work is queued.
-pub struct DeploymentOrchestrator {
-    docker_client: DockerClient,
+pub struct DeploymentOrchestrator<D: DockerExecutor = DockerClient> {
+    docker_client: D,
     github_client: GitHubClient,
     root_dir: PathBuf,
     repo_path_prefix: Option<String>,
@@ -78,10 +78,20 @@ pub struct DeploymentOrchestrator {
     deploy_semaphore: tokio::sync::Semaphore,
 }
 
-impl DeploymentOrchestrator {
+impl DeploymentOrchestrator<DockerClient> {
     pub async fn new(config: &Config, flags: SharedFlags) -> Result<Self> {
+        Self::with_executor(config, flags, DockerClient::new().await?).await
+    }
+}
+
+impl<D: DockerExecutor> DeploymentOrchestrator<D> {
+    pub async fn with_executor(
+        config: &Config,
+        flags: SharedFlags,
+        docker: D,
+    ) -> Result<Self> {
         Ok(Self {
-            docker_client: DockerClient::new().await?,
+            docker_client: docker,
             github_client: GitHubClient::new(config.github_token.clone()),
             root_dir: PathBuf::from(&config.root_dir),
             repo_path_prefix: config.repo_path_prefix.clone(),
@@ -630,17 +640,46 @@ fn duration_secs(d: Duration) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::fs::walk::ServiceEntry;
-    use std::path::PathBuf;
+    use crate::{container::docker::DockerExecutor, fs::walk::ServiceEntry};
+    use std::{future::Future, path::PathBuf};
 
-    /// Minimal orchestrator for tests that exercise pure logic (no docker calls
-    /// happen during construction; docker IS needed because DockerClient::new
-    /// verifies the compose plugin is present).
-    async fn test_orchestrator() -> DeploymentOrchestrator {
+    #[derive(Clone, Default)]
+    struct FailingDockerExecutor;
+
+    impl DockerExecutor for FailingDockerExecutor {
+        fn pull_image(
+            &self,
+            _image: &str,
+        ) -> impl Future<Output = Result<()>> + Send {
+            async { Err(eyre::eyre!("docker pull failed")) }
+        }
+
+        fn restart_compose_service(
+            &self,
+            _compose_file: &Path,
+            _service_name: &str,
+        ) -> impl Future<Output = Result<()>> + Send {
+            async { Err(eyre::eyre!("restart failed")) }
+        }
+
+        fn compose_up_service(
+            &self,
+            _compose_file: &Path,
+            _service_name: &str,
+        ) -> impl Future<Output = Result<()>> + Send {
+            async { Err(eyre::eyre!("compose up failed")) }
+        }
+    }
+
+    async fn fake_orchestrator()
+    -> DeploymentOrchestrator<crate::container::docker::CapturingDockerExecutor>
+    {
         use crate::{
             config::{Config, Mode},
+            container::docker::CapturingDockerExecutor,
             features,
         };
+
         let config = Config {
             root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
             log_level: "info".to_string(),
@@ -657,9 +696,13 @@ mod tests {
             #[cfg(feature = "otlp")]
             otlp_endpoint: "http://localhost:4317".to_string(),
         };
-        DeploymentOrchestrator::new(&config, features::new_flags())
-            .await
-            .expect("DeploymentOrchestrator::new failed — is docker installed?")
+        DeploymentOrchestrator::with_executor(
+            &config,
+            features::new_flags(),
+            CapturingDockerExecutor::new(),
+        )
+        .await
+        .expect("DeploymentOrchestrator::new failed — is docker installed?")
     }
 
     fn push_payload(
@@ -694,7 +737,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_webhook_ignores_non_default_branch() {
-        let orch = test_orchestrator().await;
+        let orch = fake_orchestrator().await;
         let payload = push_payload(
             "refs/heads/feature/my-branch",
             "main",
@@ -705,7 +748,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_webhook_ignores_non_renovate_commit() {
-        let orch = test_orchestrator().await;
+        let orch = fake_orchestrator().await;
         let payload = push_payload(
             "refs/heads/main",
             "main",
@@ -724,7 +767,7 @@ mod tests {
 
     #[tokio::test]
     async fn handle_webhook_ignores_no_compose_files() {
-        let orch = test_orchestrator().await;
+        let orch = fake_orchestrator().await;
         let payload = push_payload(
             "refs/heads/main",
             "main",
@@ -863,5 +906,130 @@ mod tests {
         let old = vec![];
         let new = vec![make_service("web", "nginx:latest", "image: nginx:latest")];
         assert_eq!(diff_services(&old, new, true).len(), 1);
+    }
+    //  -- deploy_service --
+    #[tokio::test]
+    async fn deploy_service_records_failure_in_history() {
+        use crate::{
+            config::{Config, Mode},
+            features,
+        };
+        let config = Config {
+            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
+            log_level: "info".to_string(),
+            renovate_username: "renovate[bot]".to_string(),
+            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
+            github_token: None,
+            allow_latest_images: false,
+            api_token: None,
+            mode: Mode::Webhook { secret: "test".to_string() },
+            service_filter: None,
+            repo_path_prefix: None,
+            initial_sync: true,
+            shepherd_service_name: None,
+            #[cfg(feature = "otlp")]
+            otlp_endpoint: "http://localhost:4317".to_string(),
+        };
+        let orch = DeploymentOrchestrator::with_executor(
+            &config,
+            features::new_flags(),
+            FailingDockerExecutor,
+        )
+        .await
+        .unwrap();
+        let svc = make_service("web", "nginx:1.25", "image: nginx:1.25");
+
+        let _ = orch.deploy_service(svc, None).await; // expected to fail
+
+        let history = orch.list_deployments();
+        assert_eq!(history.len(), 1);
+        assert!(matches!(history[0].status, DeploymentStatus::Failed));
+    }
+
+    #[tokio::test]
+    async fn deploy_service_blocked_by_service_filter() {
+        use crate::container::docker::CapturingDockerExecutor;
+        use crate::{
+            config::{Config, Mode},
+            features,
+        };
+        let config = Config {
+            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
+            log_level: "info".to_string(),
+            renovate_username: "renovate[bot]".to_string(),
+            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
+            github_token: None,
+            allow_latest_images: false,
+            api_token: None,
+            mode: Mode::Webhook { secret: "test".to_string() },
+            service_filter: Some(vec!["allowed".to_string()]),
+            repo_path_prefix: None,
+            initial_sync: true,
+            shepherd_service_name: None,
+            #[cfg(feature = "otlp")]
+            otlp_endpoint: "http://localhost:4317".to_string(),
+        };
+        let executor = CapturingDockerExecutor::new();
+        let orch = DeploymentOrchestrator::with_executor(
+            &config,
+            features::new_flags(),
+            executor.clone(),
+        )
+        .await
+        .unwrap();
+        let svc = make_service("blocked", "nginx:1.25", "image: nginx:1.25");
+
+        let result = orch.deploy_service(svc, None).await;
+
+        assert!(result.is_err());
+        assert!(executor.calls().is_empty(), "no docker calls should be made");
+    }
+
+    #[tokio::test]
+    async fn deploy_service_records_success_in_history() {
+        use crate::container::docker::{CapturingDockerExecutor, DockerCall};
+        let executor = CapturingDockerExecutor::new();
+        let calls = executor.calls.clone(); // Arc<Mutex<Vec<DockerCall>>>
+
+        use crate::{
+            config::{Config, Mode},
+            features,
+        };
+        let config = Config {
+            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
+            log_level: "info".to_string(),
+            renovate_username: "renovate[bot]".to_string(),
+            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
+            github_token: None,
+            allow_latest_images: false,
+            api_token: None,
+            mode: Mode::Webhook { secret: "test".to_string() },
+            service_filter: None,
+            repo_path_prefix: None,
+            initial_sync: true,
+            shepherd_service_name: None,
+            #[cfg(feature = "otlp")]
+            otlp_endpoint: "http://localhost:4317".to_string(),
+        };
+        let orch = DeploymentOrchestrator::with_executor(
+            &config,
+            features::new_flags(),
+            executor,
+        )
+        .await
+        .unwrap();
+        let svc = make_service("web", "nginx:1.25", "image: nginx:1.25");
+
+        orch.deploy_service(svc, None).await.unwrap();
+
+        let history = orch.list_deployments();
+        assert_eq!(history.len(), 1);
+        assert!(matches!(history[0].status, DeploymentStatus::Success));
+
+        let recorded = calls.lock().unwrap();
+        assert!(
+            matches!(&recorded[0], DockerCall::PullImage(img) if img == "nginx:1.25")
+        );
+        assert!(matches!(&recorded[1], DockerCall::RestartService { .. }));
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -641,33 +641,30 @@ fn duration_secs(d: Duration) -> f64 {
 mod tests {
     use super::*;
     use crate::{container::docker::DockerExecutor, fs::walk::ServiceEntry};
-    use std::{future::Future, path::PathBuf};
+    use std::path::PathBuf;
 
     #[derive(Clone, Default)]
     struct FailingDockerExecutor;
 
     impl DockerExecutor for FailingDockerExecutor {
-        fn pull_image(
-            &self,
-            _image: &str,
-        ) -> impl Future<Output = Result<()>> + Send {
-            async { Err(eyre::eyre!("docker pull failed")) }
+        async fn pull_image(&self, _image: &str) -> Result<()> {
+            Err(eyre::eyre!("docker pull failed"))
         }
 
-        fn restart_compose_service(
+        async fn restart_compose_service(
             &self,
             _compose_file: &Path,
             _service_name: &str,
-        ) -> impl Future<Output = Result<()>> + Send {
-            async { Err(eyre::eyre!("restart failed")) }
+        ) -> Result<()> {
+            Err(eyre::eyre!("restart failed"))
         }
 
-        fn compose_up_service(
+        async fn compose_up_service(
             &self,
             _compose_file: &Path,
             _service_name: &str,
-        ) -> impl Future<Output = Result<()>> + Send {
-            async { Err(eyre::eyre!("compose up failed")) }
+        ) -> Result<()> {
+            Err(eyre::eyre!("compose up failed"))
         }
     }
 

--- a/src/container/docker.rs
+++ b/src/container/docker.rs
@@ -1,11 +1,26 @@
 use color_eyre::Result;
 use eyre::{WrapErr, eyre};
-use std::{path::Path, process::Stdio, time::Duration};
+use std::{future::Future, path::Path, process::Stdio, time::Duration};
 use tokio::{process::Command as TokioCommand, time::timeout};
 
 // Per-operation ceiling: kills the docker child on expiry via kill_on_drop(true).
 const DOCKER_COMMAND_TIMEOUT: Duration = Duration::from_secs(600);
 
+pub trait DockerExecutor: Clone + Send + Sync + 'static {
+    fn pull_image(&self, image: &str) -> impl Future<Output = Result<()>> + Send;
+    fn restart_compose_service(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send;
+    fn compose_up_service(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send;
+}
+
+#[derive(Clone)]
 pub struct DockerClient {
     docker_bin: String,
 }
@@ -131,6 +146,105 @@ impl DockerClient {
     }
 }
 
+impl DockerExecutor for DockerClient {
+    fn pull_image(&self, image: &str) -> impl Future<Output = Result<()>> + Send {
+        let image = image.to_owned();
+        async move { self.pull_image(&image).await }
+    }
+
+    fn restart_compose_service(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send {
+        let path = compose_file.to_owned();
+        let name = service_name.to_owned();
+        async move { self.restart_compose_service(&path, &name).await }
+    }
+
+    fn compose_up_service(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send {
+        let path = compose_file.to_owned();
+        let name = service_name.to_owned();
+        async move { self.compose_up_service(&path, &name).await }
+    }
+}
+
+#[cfg(test)]
+#[allow(dead_code)] // This enum is testing only. I'll keep the variables as is.
+#[derive(Debug, Clone)]
+pub enum DockerCall {
+    PullImage(String),
+    RestartService { path: std::path::PathBuf, service: String },
+    ComposeUp { path: std::path::PathBuf, service: String },
+}
+
+#[cfg(test)]
+use std::sync::{Arc, Mutex};
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub struct CapturingDockerExecutor {
+    pub calls: Arc<Mutex<Vec<DockerCall>>>,
+}
+
+#[cfg(test)]
+impl CapturingDockerExecutor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn calls(&self) -> Vec<DockerCall> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+#[cfg(test)]
+impl DockerExecutor for CapturingDockerExecutor {
+    fn pull_image(&self, image: &str) -> impl Future<Output = Result<()>> + Send {
+        let image = image.to_owned();
+        async move {
+            self.calls.lock().unwrap().push(DockerCall::PullImage(image));
+            Ok(())
+        }
+    }
+
+    fn restart_compose_service(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send {
+        let path = compose_file.to_owned();
+        let name = service_name.to_owned();
+        async move {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(DockerCall::RestartService { path, service: name });
+            Ok(())
+        }
+    }
+
+    fn compose_up_service(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+    ) -> impl Future<Output = Result<()>> + Send {
+        let path = compose_file.to_owned();
+        let name = service_name.to_owned();
+        async move {
+            self.calls
+                .lock()
+                .unwrap()
+                .push(DockerCall::ComposeUp { path, service: name });
+            Ok(())
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,14 +262,18 @@ mod tests {
             .expect("Failed to remove test image");
     }
 
+    // Instead of relying on underlying host to provide container runtime, we use mocked version
     #[tokio::test]
-    async fn test_find_docker() {
-        assert!(DockerClient::find_executable("docker").is_ok());
-    }
+    async fn test_docker_executor_logic_with_fake() {
+        let executor = CapturingDockerExecutor::new();
+        let compose_path = std::path::Path::new("docker-compose.yaml");
 
-    #[tokio::test]
-    async fn test_verify_compose_available() {
-        let result = DockerClient::verify_compose_available().await;
-        assert!(result.is_ok(), "docker compose not available: {result:?}");
+        executor.pull_image("alpine:latest").await.unwrap();
+        executor.compose_up_service(compose_path, "web").await.unwrap();
+        executor.compose_up_service(compose_path, "db").await.unwrap();
+
+        let calls = executor.calls();
+        assert_eq!(calls.len(), 3);
+        assert!(matches!(calls[0], DockerCall::PullImage(_)));
     }
 }

--- a/src/container/docker.rs
+++ b/src/container/docker.rs
@@ -6,13 +6,22 @@ use tokio::{process::Command as TokioCommand, time::timeout};
 // Per-operation ceiling: kills the docker child on expiry via kill_on_drop(true).
 const DOCKER_COMMAND_TIMEOUT: Duration = Duration::from_secs(600);
 
+/// Provides an interface for Docker container lifecycle operations.
+///
+/// Implementations allow pulling images and managing Docker Compose services,
+/// enabling unit testing via mocks or fake implementations.
 pub trait DockerExecutor: Clone + Send + Sync + 'static {
+    /// Pulls a target container image from a registry
     fn pull_image(&self, image: &str) -> impl Future<Output = Result<()>> + Send;
+
+    /// Forces a restart and recreation of a specific Compose service
     fn restart_compose_service(
         &self,
         compose_file: &Path,
         service_name: &str,
     ) -> impl Future<Output = Result<()>> + Send;
+
+    /// Starts or updates a single service defined in a Compose file without recreating dependencies
     fn compose_up_service(
         &self,
         compose_file: &Path,
@@ -22,22 +31,30 @@ pub trait DockerExecutor: Clone + Send + Sync + 'static {
 
 #[derive(Clone)]
 pub struct DockerClient {
+    /// System path to the local `docker` executable
     docker_bin: String,
 }
 
 impl DockerClient {
+    /// Creates a new DockerClient
+    ///
+    /// Returns an error if the docker binary cannot be located on 'PATH'
+    /// or if docker compose (v2) is unavailable.
     pub async fn new() -> Result<Self> {
         let docker_bin = Self::find_executable("docker")?;
         Self::verify_compose_available().await?;
         Ok(Self { docker_bin })
     }
 
+    /// Resolves the absolute system path for a given binary name using the environment 'PATH'
     fn find_executable(name: &str) -> Result<String> {
         which::which(name)
             .wrap_err_with(|| format!("Failed to find executable: {}", name))
             .map(|p| p.to_string_lossy().to_string())
     }
 
+    /// Verifies that the docker compose V2 is installed
+    /// V2 means `docker compose`.
     pub(crate) async fn verify_compose_available() -> Result<()> {
         let ok = TokioCommand::new("docker")
             .args(["compose", "version"])

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -1,12 +1,16 @@
-use crate::container::{DeploymentOrchestrator, github::GitHubClient};
+use crate::container::{
+    DeploymentOrchestrator,
+    docker::{DockerClient, DockerExecutor},
+    github::GitHubClient,
+};
 use crate::features::SharedFlags;
 use color_eyre::Result;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
-pub struct Poller {
-    orchestrator: Arc<DeploymentOrchestrator>,
+pub struct Poller<D: DockerExecutor = DockerClient> {
+    orchestrator: Arc<DeploymentOrchestrator<D>>,
     // TODO: consolidate with DeploymentOrchestrator's github_client once the
     // Poller and Orchestrator are unified or the client is made cheaply clonable.
     github: GitHubClient,
@@ -21,9 +25,9 @@ pub struct Poller {
     last_sha: Mutex<Option<String>>,
 }
 
-impl Poller {
+impl<D: DockerExecutor> Poller<D> {
     pub fn new(
-        orchestrator: Arc<DeploymentOrchestrator>,
+        orchestrator: Arc<DeploymentOrchestrator<D>>,
         flags: SharedFlags,
         config: &crate::config::Config,
     ) -> Self {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -14,8 +14,11 @@ use subtle::ConstantTimeEq;
 
 use crate::config::Config;
 use crate::container::{
-    self, Deployment, DeploymentOrchestrator, webhook::WebhookEvent,
+    self, Deployment, DeploymentOrchestrator,
+    docker::{DockerClient, DockerExecutor},
+    webhook::WebhookEvent,
 };
+
 use crate::features::SharedFlags;
 
 #[cfg(feature = "metrics")]
@@ -25,15 +28,15 @@ use axum_prometheus::PrometheusMetricLayer;
 use axum_tracing_opentelemetry::middleware::{OtelAxumLayer, OtelInResponseLayer};
 
 #[derive(Clone)]
-pub struct AppState {
+pub struct AppState<D: DockerExecutor = DockerClient> {
     pub config: Arc<Config>,
-    pub orchestrator: Arc<DeploymentOrchestrator>,
+    pub orchestrator: Arc<DeploymentOrchestrator<D>>,
     pub flags: SharedFlags,
 }
 
 /// Build the complete router. This is the single place that owns all route
 /// definitions and their middleware — `main` just binds and serves.
-pub fn router(state: AppState) -> axum::Router {
+pub fn router<D: DockerExecutor>(state: AppState<D>) -> axum::Router {
     if state.config.api_token.is_none() {
         tracing::warn!("API_TOKEN not set; /flags/* endpoints will return 401");
     }
@@ -94,8 +97,8 @@ fn unauthorized(reason: &str) -> Response {
         .into_response()
 }
 
-pub async fn require_api_token(
-    State(state): State<AppState>,
+pub async fn require_api_token<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
     req: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
@@ -169,8 +172,8 @@ pub(crate) struct ReadyChecks {
 ///
 /// Answers "should k8s restart this pod?". Checks only that ROOT_DIR is
 /// accessible. Intentionally lightweight: no subprocess, no network calls.
-pub(crate) async fn health_check(
-    State(state): State<AppState>,
+pub(crate) async fn health_check<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
 ) -> (StatusCode, Json<HealthResponse>) {
     let root_dir = &state.config.root_dir;
     match tokio::fs::metadata(root_dir).await {
@@ -197,8 +200,8 @@ pub(crate) async fn health_check(
 /// Answers "should k8s send traffic to this pod?". Runs both checks
 /// independently so the response always shows per-check detail regardless
 /// of which one fails.
-pub(crate) async fn readiness_check(
-    State(state): State<AppState>,
+pub(crate) async fn readiness_check<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
 ) -> (StatusCode, Json<ReadyResponse>) {
     let (root_dir_result, docker_result) = tokio::join!(
         tokio::fs::metadata(&state.config.root_dir),
@@ -248,8 +251,8 @@ pub struct ManagedServicesResponse {
     pub total: usize,
 }
 
-pub async fn list_managed_services(
-    State(state): State<AppState>,
+pub async fn list_managed_services<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
 ) -> Result<Json<ManagedServicesResponse>, StatusCode> {
     let services = state.orchestrator.get_managed_services().await.map_err(|e| {
         tracing::error!("Failed to get managed services: {:?}", e);
@@ -259,8 +262,8 @@ pub async fn list_managed_services(
     Ok(Json(ManagedServicesResponse { services, total }))
 }
 
-pub async fn github_webhook(
-    State(state): State<AppState>,
+pub async fn github_webhook<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
     headers: HeaderMap,
     body: Bytes,
 ) -> StatusCode {
@@ -332,8 +335,8 @@ pub async fn github_webhook(
     StatusCode::ACCEPTED
 }
 
-pub async fn list_deployments(
-    State(state): State<AppState>,
+pub async fn list_deployments<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
 ) -> Json<Vec<Deployment>> {
     Json(state.orchestrator.list_deployments())
 }
@@ -347,8 +350,8 @@ pub struct ManualDeployRequest {
     pub image: Option<String>,
 }
 
-pub async fn manual_deploy(
-    State(state): State<AppState>,
+pub async fn manual_deploy<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
     Json(req): Json<ManualDeployRequest>,
 ) -> StatusCode {
     if state.flags.load().deployments_paused {
@@ -381,7 +384,9 @@ pub async fn manual_deploy(
     StatusCode::ACCEPTED
 }
 
-pub async fn trigger_sync(State(state): State<AppState>) -> StatusCode {
+pub async fn trigger_sync<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
+) -> StatusCode {
     if state.flags.load().deployments_paused {
         tracing::info!("Deployments paused, rejecting sync request");
         return StatusCode::SERVICE_UNAVAILABLE;
@@ -403,7 +408,9 @@ pub struct FlagsResponse {
     pub dry_run: bool,
 }
 
-pub async fn get_flags(State(state): State<AppState>) -> Json<FlagsResponse> {
+pub async fn get_flags<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
+) -> Json<FlagsResponse> {
     let f = state.flags.load();
     Json(FlagsResponse {
         deployments_paused: f.deployments_paused,
@@ -411,7 +418,9 @@ pub async fn get_flags(State(state): State<AppState>) -> Json<FlagsResponse> {
     })
 }
 
-pub async fn pause_deployments(State(state): State<AppState>) -> StatusCode {
+pub async fn pause_deployments<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
+) -> StatusCode {
     state.flags.rcu(|f| crate::features::RuntimeFlags {
         deployments_paused: true,
         ..(**f).clone()
@@ -421,7 +430,9 @@ pub async fn pause_deployments(State(state): State<AppState>) -> StatusCode {
     StatusCode::OK
 }
 
-pub async fn resume_deployments(State(state): State<AppState>) -> StatusCode {
+pub async fn resume_deployments<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
+) -> StatusCode {
     state.flags.rcu(|f| crate::features::RuntimeFlags {
         deployments_paused: false,
         ..(**f).clone()
@@ -431,7 +442,9 @@ pub async fn resume_deployments(State(state): State<AppState>) -> StatusCode {
     StatusCode::OK
 }
 
-pub async fn enable_dry_run(State(state): State<AppState>) -> StatusCode {
+pub async fn enable_dry_run<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
+) -> StatusCode {
     state
         .flags
         .rcu(|f| crate::features::RuntimeFlags { dry_run: true, ..(**f).clone() });
@@ -440,7 +453,9 @@ pub async fn enable_dry_run(State(state): State<AppState>) -> StatusCode {
     StatusCode::OK
 }
 
-pub async fn disable_dry_run(State(state): State<AppState>) -> StatusCode {
+pub async fn disable_dry_run<D: DockerExecutor>(
+    State(state): State<AppState<D>>,
+) -> StatusCode {
     state
         .flags
         .rcu(|f| crate::features::RuntimeFlags { dry_run: false, ..(**f).clone() });
@@ -513,9 +528,12 @@ mod tests {
     /// Requires docker to be installed (DeploymentOrchestrator::new calls
     /// `docker compose version` on startup). Tests are not marked #[ignore]
     /// because docker is available in this project's CI environment.
-    async fn test_state(api_token: Option<&str>) -> AppState {
+    async fn test_state(
+        api_token: Option<&str>,
+    ) -> AppState<crate::container::docker::CapturingDockerExecutor> {
         use crate::{
             config::{Config, Mode},
+            container::docker::CapturingDockerExecutor,
             features,
         };
         let config = Arc::new(Config {
@@ -535,14 +553,17 @@ mod tests {
             otlp_endpoint: "http://localhost:4317".to_string(),
         });
         let flags = features::new_flags();
-        let orchestrator =
-            crate::container::DeploymentOrchestrator::new(&config, flags.clone())
-                .await
-                .expect("DeploymentOrchestrator::new failed — is docker installed?");
+        let orchestrator = crate::container::DeploymentOrchestrator::with_executor(
+            &config,
+            flags.clone(),
+            CapturingDockerExecutor::new(),
+        )
+        .await
+        .expect("DeploymentOrchestrator::new failed — is docker installed?");
         AppState { config, orchestrator: Arc::new(orchestrator), flags }
     }
 
-    fn token_test_app(state: AppState) -> axum::Router {
+    fn token_test_app<D: DockerExecutor>(state: AppState<D>) -> axum::Router {
         axum::Router::new()
             .route("/", get(|| async { StatusCode::OK }))
             .route_layer(axum::middleware::from_fn_with_state(


### PR DESCRIPTION
DeploymentOrchestrator directly owns a concrete DockerClient with no seam.  Its new() spawns a real docker compose version subprocess, so every test that constructs an orchestrator  including tests for pure filtering logic like branch checking and Renovate author detection) requires a live Docker daemon.

So extracting DockerExecutor trait with three methods(pull_image, restart_compose service, compose_up_service) and make DockerClient one adapter of it allows me writing tests using CapturingDockerExecutor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved deployment and service-management components for greater flexibility and maintainability.
  - Added configurable container execution while preserving the default deployment behavior.
  - Existing deployment, webhook, health, readiness, and manual control workflows continue to operate as expected.

- **Tests**
  - Expanded coverage for successful and failed deployments, webhook handling, service filtering, deployment history, and container operations.
  - Added reliable validation without requiring a local container runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->