### PR TITLE
refactor: unify compose filter, share Arc<Config>, clean up webhook handler

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,28 @@ pub struct Config {
     pub repo_path_prefix: Option<String>,
 }
 
+#[cfg(test)]
+impl Config {
+    pub(crate) fn for_test(api_token: Option<&str>) -> Self {
+        Config {
+            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
+            log_level: "info".to_string(),
+            renovate_username: "renovate[bot]".to_string(),
+            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
+            github_token: None,
+            allow_latest_images: false,
+            api_token: api_token.map(String::from),
+            mode: Mode::Webhook { secret: "test".to_string() },
+            service_filter: None,
+            repo_path_prefix: None,
+            initial_sync: true,
+            shepherd_service_name: None,
+            #[cfg(feature = "otlp")]
+            otlp_endpoint: "http://localhost:4317".to_string(),
+        }
+    }
+}
+
 impl Config {
     pub fn load() -> Result<Self, String> {
         // Load .env if it exists; ignore errors

--- a/src/container.rs
+++ b/src/container.rs
@@ -15,7 +15,7 @@ use eyre::{WrapErr, eyre};
 use serde::Serialize;
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Maximum time to wait for the deploy semaphore before returning an error.
@@ -61,14 +61,8 @@ pub struct Deployment {
 /// the HTTP response is immediate, but the actual deploy work is queued.
 pub struct DeploymentOrchestrator<D: DockerExecutor = DockerClient> {
     docker_client: D,
-    github_client: GitHubClient,
-    root_dir: PathBuf,
-    repo_path_prefix: Option<String>,
-    service_filter: Option<Vec<String>>,
-    renovate_username: String,
-    renovate_email: String,
-    allow_latest: bool,
-    shepherd_service_name: Option<String>,
+    github_client: Arc<GitHubClient>,
+    config: Arc<Config>,
     flags: SharedFlags,
     /// Deployment history, capped at 200 entries. Uses a std Mutex because
     /// the critical section is microseconds — just a VecDeque push.
@@ -79,37 +73,37 @@ pub struct DeploymentOrchestrator<D: DockerExecutor = DockerClient> {
 }
 
 impl DeploymentOrchestrator<DockerClient> {
-    pub async fn new(config: &Config, flags: SharedFlags) -> Result<Self> {
-        Self::with_executor(config, flags, DockerClient::new().await?).await
+    pub async fn new(config: Arc<Config>, flags: SharedFlags) -> Result<Self> {
+        let github_client = Arc::new(GitHubClient::new(config.github_token.clone()));
+        Self::with_executor(config, github_client, flags, DockerClient::new().await?).await
     }
 }
 
 impl<D: DockerExecutor> DeploymentOrchestrator<D> {
     pub async fn with_executor(
-        config: &Config,
+        config: Arc<Config>,
+        github_client: Arc<GitHubClient>,
         flags: SharedFlags,
         docker: D,
     ) -> Result<Self> {
         Ok(Self {
             docker_client: docker,
-            github_client: GitHubClient::new(config.github_token.clone()),
-            root_dir: PathBuf::from(&config.root_dir),
-            repo_path_prefix: config.repo_path_prefix.clone(),
-            service_filter: config.service_filter.clone(),
-            renovate_username: config.renovate_username.clone(),
-            renovate_email: config.renovate_email.clone(),
-            allow_latest: config.allow_latest_images,
-            shepherd_service_name: config.shepherd_service_name.clone(),
+            github_client,
+            config,
             flags,
             history: Mutex::new(VecDeque::new()),
             deploy_semaphore: tokio::sync::Semaphore::new(1),
         })
     }
 
+    pub fn github_client(&self) -> Arc<GitHubClient> {
+        Arc::clone(&self.github_client)
+    }
+
     // ── public API ────────────────────────────────────────────────────────────
 
     pub async fn get_managed_services(&self) -> Result<Vec<ServiceEntry>> {
-        let root = self.root_dir.clone();
+        let root = PathBuf::from(&self.config.root_dir);
         let services = tokio::task::spawn_blocking(move || {
             crate::fs::walk::scan_filesystem(&root)
         })
@@ -150,7 +144,7 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
         let service = match image {
             Some(img) => {
                 let image_ref = ImageReference::parse(&img)?;
-                check_tag_policy(&service.name, &image_ref, self.allow_latest)?;
+                check_tag_policy(&service.name, &image_ref, self.config.allow_latest_images)?;
                 let (path, name, img_for_write) =
                     (service.path.clone(), service.name.clone(), img.clone());
                 tokio::task::spawn_blocking(move || {
@@ -172,7 +166,7 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
             }
             None => {
                 let image_ref = ImageReference::parse(&service.image)?;
-                check_tag_policy(&service.name, &image_ref, self.allow_latest)?;
+                check_tag_policy(&service.name, &image_ref, self.config.allow_latest_images)?;
                 service
             }
         };
@@ -210,7 +204,7 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
                 }
             };
             if let Err(e) =
-                check_tag_policy(&service.name, &image_ref, self.allow_latest)
+                check_tag_policy(&service.name, &image_ref, self.config.allow_latest_images)
             {
                 tracing::warn!("{e}");
                 continue;
@@ -251,7 +245,7 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
             return Ok(());
         }
         let modified: Vec<String> = payload
-            .modified_compose_files(&self.renovate_username, &self.renovate_email)
+            .modified_compose_files(&self.config.renovate_username, &self.config.renovate_email)
             .into_iter()
             .collect();
         if modified.is_empty() {
@@ -311,7 +305,7 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
                 .await
             {
                 Ok((old, new)) => to_restart.extend(
-                    diff_services(&old, new, self.allow_latest).into_iter().filter(
+                    diff_services(&old, new, self.config.allow_latest_images).into_iter().filter(
                         |s| {
                             if self.is_service_allowed(&s.name) {
                                 true
@@ -336,12 +330,13 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
 
         // Sort so shepherd itself always deploys last. This ensures sibling
         // services are running before shepherd replaces its own container.
-        if let Some(self_name) = &self.shepherd_service_name {
+        if let Some(self_name) = &self.config.shepherd_service_name {
             to_restart.sort_by_key(|s| s.name.eq_ignore_ascii_case(self_name));
         }
 
         for service in to_restart {
             if self
+                .config
                 .shepherd_service_name
                 .as_deref()
                 .is_some_and(|n| n.eq_ignore_ascii_case(&service.name))
@@ -364,13 +359,13 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
     // ── internals ─────────────────────────────────────────────────────────────
 
     fn strip_repo_prefix<'a>(&self, github_path: &'a str) -> Option<&'a str> {
-        strip_repo_prefix_inner(self.repo_path_prefix.as_deref(), github_path)
+        strip_repo_prefix_inner(self.config.repo_path_prefix.as_deref(), github_path)
     }
 
     /// Returns true if the service is allowed to be deployed on this instance.
     /// When no filter is configured, all services are allowed.
     fn is_service_allowed(&self, name: &str) -> bool {
-        match &self.service_filter {
+        match &self.config.service_filter {
             None => true,
             Some(filter) => filter.iter().any(|f| f.eq_ignore_ascii_case(name)),
         }
@@ -405,7 +400,7 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
             return Err(eyre!("Rejected suspicious file path: {local_rel:?}"));
         }
 
-        let local_path = self.root_dir.join(local_rel);
+        let local_path = PathBuf::from(&self.config.root_dir).join(local_rel);
 
         let old_services = if local_path.exists() {
             crate::fs::walk::parse_yaml_file(&local_path).unwrap_or_default()
@@ -429,7 +424,7 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
         // If a service filter is set and none of the services in this file
         // match it, skip the write entirely — no point creating files or
         // directories for services this instance will never deploy.
-        if self.service_filter.is_some()
+        if self.config.service_filter.is_some()
             && !new_services.iter().any(|s| self.is_service_allowed(&s.name))
         {
             tracing::debug!("Skipping file: no services match SERVICE_FILTER");
@@ -672,34 +667,20 @@ mod tests {
     -> DeploymentOrchestrator<crate::container::docker::CapturingDockerExecutor>
     {
         use crate::{
-            config::{Config, Mode},
-            container::docker::CapturingDockerExecutor,
+            config::Config,
+            container::{docker::CapturingDockerExecutor, github::GitHubClient},
             features,
         };
-
-        let config = Config {
-            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
-            log_level: "info".to_string(),
-            renovate_username: "renovate[bot]".to_string(),
-            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
-            github_token: None,
-            allow_latest_images: false,
-            api_token: None,
-            mode: Mode::Webhook { secret: "test".to_string() },
-            service_filter: None,
-            repo_path_prefix: None,
-            initial_sync: true,
-            shepherd_service_name: None,
-            #[cfg(feature = "otlp")]
-            otlp_endpoint: "http://localhost:4317".to_string(),
-        };
+        let config = std::sync::Arc::new(Config::for_test(None));
+        let github_client = std::sync::Arc::new(GitHubClient::new(None));
         DeploymentOrchestrator::with_executor(
-            &config,
+            config,
+            github_client,
             features::new_flags(),
             CapturingDockerExecutor::new(),
         )
         .await
-        .expect("DeploymentOrchestrator::new failed — is docker installed?")
+        .expect("DeploymentOrchestrator::with_executor failed")
     }
 
     fn push_payload(
@@ -907,28 +888,12 @@ mod tests {
     //  -- deploy_service --
     #[tokio::test]
     async fn deploy_service_records_failure_in_history() {
-        use crate::{
-            config::{Config, Mode},
-            features,
-        };
-        let config = Config {
-            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
-            log_level: "info".to_string(),
-            renovate_username: "renovate[bot]".to_string(),
-            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
-            github_token: None,
-            allow_latest_images: false,
-            api_token: None,
-            mode: Mode::Webhook { secret: "test".to_string() },
-            service_filter: None,
-            repo_path_prefix: None,
-            initial_sync: true,
-            shepherd_service_name: None,
-            #[cfg(feature = "otlp")]
-            otlp_endpoint: "http://localhost:4317".to_string(),
-        };
+        use crate::{config::Config, container::github::GitHubClient, features};
+        let config = std::sync::Arc::new(Config::for_test(None));
+        let github_client = std::sync::Arc::new(GitHubClient::new(None));
         let orch = DeploymentOrchestrator::with_executor(
-            &config,
+            config,
+            github_client,
             features::new_flags(),
             FailingDockerExecutor,
         )
@@ -945,30 +910,20 @@ mod tests {
 
     #[tokio::test]
     async fn deploy_service_blocked_by_service_filter() {
-        use crate::container::docker::CapturingDockerExecutor;
         use crate::{
-            config::{Config, Mode},
+            config::Config,
+            container::{docker::CapturingDockerExecutor, github::GitHubClient},
             features,
         };
-        let config = Config {
-            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
-            log_level: "info".to_string(),
-            renovate_username: "renovate[bot]".to_string(),
-            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
-            github_token: None,
-            allow_latest_images: false,
-            api_token: None,
-            mode: Mode::Webhook { secret: "test".to_string() },
+        let config = std::sync::Arc::new(Config {
             service_filter: Some(vec!["allowed".to_string()]),
-            repo_path_prefix: None,
-            initial_sync: true,
-            shepherd_service_name: None,
-            #[cfg(feature = "otlp")]
-            otlp_endpoint: "http://localhost:4317".to_string(),
-        };
+            ..Config::for_test(None)
+        });
+        let github_client = std::sync::Arc::new(GitHubClient::new(None));
         let executor = CapturingDockerExecutor::new();
         let orch = DeploymentOrchestrator::with_executor(
-            &config,
+            config,
+            github_client,
             features::new_flags(),
             executor.clone(),
         )
@@ -984,32 +939,21 @@ mod tests {
 
     #[tokio::test]
     async fn deploy_service_records_success_in_history() {
-        use crate::container::docker::{CapturingDockerExecutor, DockerCall};
-        let executor = CapturingDockerExecutor::new();
-        let calls = executor.calls.clone(); // Arc<Mutex<Vec<DockerCall>>>
-
         use crate::{
-            config::{Config, Mode},
+            config::Config,
+            container::{
+                docker::{CapturingDockerExecutor, DockerCall},
+                github::GitHubClient,
+            },
             features,
         };
-        let config = Config {
-            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
-            log_level: "info".to_string(),
-            renovate_username: "renovate[bot]".to_string(),
-            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
-            github_token: None,
-            allow_latest_images: false,
-            api_token: None,
-            mode: Mode::Webhook { secret: "test".to_string() },
-            service_filter: None,
-            repo_path_prefix: None,
-            initial_sync: true,
-            shepherd_service_name: None,
-            #[cfg(feature = "otlp")]
-            otlp_endpoint: "http://localhost:4317".to_string(),
-        };
+        let executor = CapturingDockerExecutor::new();
+        let calls = executor.calls.clone();
+        let config = std::sync::Arc::new(Config::for_test(None));
+        let github_client = std::sync::Arc::new(GitHubClient::new(None));
         let orch = DeploymentOrchestrator::with_executor(
-            &config,
+            config,
+            github_client,
             features::new_flags(),
             executor,
         )

--- a/src/container.rs
+++ b/src/container.rs
@@ -75,7 +75,8 @@ pub struct DeploymentOrchestrator<D: DockerExecutor = DockerClient> {
 impl DeploymentOrchestrator<DockerClient> {
     pub async fn new(config: Arc<Config>, flags: SharedFlags) -> Result<Self> {
         let github_client = Arc::new(GitHubClient::new(config.github_token.clone()));
-        Self::with_executor(config, github_client, flags, DockerClient::new().await?).await
+        Self::with_executor(config, github_client, flags, DockerClient::new().await?)
+            .await
     }
 }
 
@@ -144,7 +145,11 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
         let service = match image {
             Some(img) => {
                 let image_ref = ImageReference::parse(&img)?;
-                check_tag_policy(&service.name, &image_ref, self.config.allow_latest_images)?;
+                check_tag_policy(
+                    &service.name,
+                    &image_ref,
+                    self.config.allow_latest_images,
+                )?;
                 let (path, name, img_for_write) =
                     (service.path.clone(), service.name.clone(), img.clone());
                 tokio::task::spawn_blocking(move || {
@@ -166,7 +171,11 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
             }
             None => {
                 let image_ref = ImageReference::parse(&service.image)?;
-                check_tag_policy(&service.name, &image_ref, self.config.allow_latest_images)?;
+                check_tag_policy(
+                    &service.name,
+                    &image_ref,
+                    self.config.allow_latest_images,
+                )?;
                 service
             }
         };
@@ -203,9 +212,11 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
                     continue;
                 }
             };
-            if let Err(e) =
-                check_tag_policy(&service.name, &image_ref, self.config.allow_latest_images)
-            {
+            if let Err(e) = check_tag_policy(
+                &service.name,
+                &image_ref,
+                self.config.allow_latest_images,
+            ) {
                 tracing::warn!("{e}");
                 continue;
             }
@@ -245,7 +256,10 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
             return Ok(());
         }
         let modified: Vec<String> = payload
-            .modified_compose_files(&self.config.renovate_username, &self.config.renovate_email)
+            .modified_compose_files(
+                &self.config.renovate_username,
+                &self.config.renovate_email,
+            )
             .into_iter()
             .collect();
         if modified.is_empty() {
@@ -305,8 +319,9 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
                 .await
             {
                 Ok((old, new)) => to_restart.extend(
-                    diff_services(&old, new, self.config.allow_latest_images).into_iter().filter(
-                        |s| {
+                    diff_services(&old, new, self.config.allow_latest_images)
+                        .into_iter()
+                        .filter(|s| {
                             if self.is_service_allowed(&s.name) {
                                 true
                             } else {
@@ -316,8 +331,7 @@ impl<D: DockerExecutor> DeploymentOrchestrator<D> {
                                 );
                                 false
                             }
-                        },
-                    ),
+                        }),
                 ),
                 Err(e) => tracing::warn!("Failed to sync {github_path}: {e:?}"),
             }

--- a/src/container/webhook.rs
+++ b/src/container/webhook.rs
@@ -121,7 +121,7 @@ impl WebhookPayload {
                 )
             })
             .flat_map(|c| c.modified.iter().chain(c.added.iter()))
-            .filter(|f| f.ends_with(".yaml"))
+            .filter(|f| crate::fs::walk::is_compose_file(f))
             .cloned()
             .collect()
     }

--- a/src/fs/walk.rs
+++ b/src/fs/walk.rs
@@ -29,7 +29,7 @@ pub fn scan_filesystem(root: &Path) -> Result<Vec<ServiceEntry>> {
 
         tracing::debug!("Visiting path: {:?}", path);
 
-        if path.extension().map(|e| e == "yaml").unwrap_or(false) {
+        if path.to_str().map(is_compose_file).unwrap_or(false) {
             tracing::debug!("Parsing YAML file: {:?}", path);
             match parse_yaml_file(path) {
                 Ok(entries) => results.extend(entries),
@@ -123,8 +123,8 @@ fn replace_image_in_place(
                 replaced = true;
                 continue;
             }
-        // Matches `service_name` only. Quoted keys are not handled.
         } else if stripped == format!("{}:", service_name) {
+            // Matches `service_name` only. Quoted keys are not handled.
             in_service = true;
             service_indent = indent;
         }
@@ -143,6 +143,15 @@ fn replace_image_in_place(
     }
 
     Some(out)
+}
+
+/// Returns true if `path` ends with a canonical compose file name.
+///
+/// Matches only the filename component, not a suffix of a longer name, so
+/// `not-compose.yaml` is not accepted.
+pub(crate) fn is_compose_file(path: &str) -> bool {
+    let name = path.rsplit('/').next().unwrap_or(path);
+    matches!(name, "compose.yaml" | "docker-compose.yaml")
 }
 
 pub(crate) fn parse_yaml_file(path: &Path) -> Result<Vec<ServiceEntry>> {
@@ -188,6 +197,32 @@ pub(crate) fn parse_yaml_str(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compose_yaml_accepted() {
+        assert!(is_compose_file("compose.yaml"));
+        assert!(is_compose_file("apps/myapp/compose.yaml"));
+    }
+
+    #[test]
+    fn docker_compose_yaml_accepted() {
+        assert!(is_compose_file("docker-compose.yaml"));
+        assert!(is_compose_file("infra/svc/docker-compose.yaml"));
+    }
+
+    #[test]
+    fn arbitrary_yaml_rejected() {
+        assert!(!is_compose_file("renovate.yaml"));
+        assert!(!is_compose_file(".renovaterc.yaml"));
+        assert!(!is_compose_file("ci.yml"));
+        assert!(!is_compose_file("not-compose.yaml"));
+    }
+
+    #[test]
+    fn yml_variants_rejected() {
+        assert!(!is_compose_file("compose.yml"));
+        assert!(!is_compose_file("docker-compose.yml"));
+    }
     use std::fs::File;
     use std::io::Write;
     use tempfile::tempdir;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ async fn serve(
 
     let flags = features::new_flags();
 
-    let orchestrator = DeploymentOrchestrator::new(&config, flags.clone())
+    let orchestrator = DeploymentOrchestrator::new(Arc::clone(&config), flags.clone())
         .await
         .unwrap_or_else(|e| {
             eprintln!("Failed to initialize orchestrator: {e}");
@@ -78,8 +78,9 @@ async fn serve(
         config::Mode::Poll { repo, interval_secs, .. } => {
             let p = poller::Poller::new(
                 Arc::clone(&state.orchestrator),
+                state.orchestrator.github_client(),
                 state.flags.clone(),
-                &state.config,
+                Arc::clone(&state.config),
             );
             tracing::info!(repo = %repo, interval_secs, "Polling mode active");
             tokio::spawn(async move { p.run().await });

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,12 +65,13 @@ async fn serve(
 
     let flags = features::new_flags();
 
-    let orchestrator = DeploymentOrchestrator::new(Arc::clone(&config), flags.clone())
-        .await
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to initialize orchestrator: {e}");
-            std::process::exit(1);
-        });
+    let orchestrator =
+        DeploymentOrchestrator::new(Arc::clone(&config), flags.clone())
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to initialize orchestrator: {e}");
+                std::process::exit(1);
+            });
 
     let state = AppState { config, orchestrator: Arc::new(orchestrator), flags };
 

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -1,9 +1,11 @@
+use crate::config::Config;
 use crate::container::{
     DeploymentOrchestrator,
     docker::{DockerClient, DockerExecutor},
     github::GitHubClient,
 };
 use crate::features::SharedFlags;
+use crate::fs::walk::is_compose_file;
 use color_eyre::Result;
 use std::sync::Arc;
 use std::time::Duration;
@@ -11,16 +13,12 @@ use tokio::sync::Mutex;
 
 pub struct Poller<D: DockerExecutor = DockerClient> {
     orchestrator: Arc<DeploymentOrchestrator<D>>,
-    // TODO: consolidate with DeploymentOrchestrator's github_client once the
-    // Poller and Orchestrator are unified or the client is made cheaply clonable.
-    github: GitHubClient,
+    github: Arc<GitHubClient>,
+    config: Arc<Config>,
     owner: String,
     repo: String,
     branch: String,
     interval: Duration,
-    renovate_username: String,
-    renovate_email: String,
-    repo_path_prefix: Option<String>,
     flags: SharedFlags,
     last_sha: Mutex<Option<String>>,
 }
@@ -28,8 +26,9 @@ pub struct Poller<D: DockerExecutor = DockerClient> {
 impl<D: DockerExecutor> Poller<D> {
     pub fn new(
         orchestrator: Arc<DeploymentOrchestrator<D>>,
+        github_client: Arc<GitHubClient>,
         flags: SharedFlags,
-        config: &crate::config::Config,
+        config: Arc<Config>,
     ) -> Self {
         let (owner, repo, branch, interval) = match &config.mode {
             crate::config::Mode::Poll { repo, interval_secs, branch } => {
@@ -48,14 +47,12 @@ impl<D: DockerExecutor> Poller<D> {
             }
         };
         Self {
-            github: GitHubClient::new(config.github_token.clone()),
+            github: github_client,
             owner,
             repo,
             branch,
             interval,
-            renovate_username: config.renovate_username.clone(),
-            renovate_email: config.renovate_email.clone(),
-            repo_path_prefix: config.repo_path_prefix.clone(),
+            config,
             flags,
             orchestrator,
             last_sha: Mutex::new(None),
@@ -159,7 +156,7 @@ impl<D: DockerExecutor> Poller<D> {
         let files =
             self.github.list_repo_files(&self.owner, &self.repo, sha).await?;
 
-        let prefix = self.repo_path_prefix.as_deref().unwrap_or("");
+        let prefix = self.config.repo_path_prefix.as_deref().unwrap_or("");
         let compose_files: Vec<String> = files
             .into_iter()
             .filter(|f| {
@@ -183,49 +180,9 @@ impl<D: DockerExecutor> Poller<D> {
             commit.author_login.as_deref(),
             &commit.author_name,
             &commit.author_email,
-            &self.renovate_username,
-            &self.renovate_email,
+            &self.config.renovate_username,
+            &self.config.renovate_email,
         )
     }
 }
 
-/// Returns true if `path` ends with a canonical compose file name.
-///
-/// Matches only the filename component, not a suffix of a longer name, so
-/// `not-compose.yaml` is not accepted.
-fn is_compose_file(path: &str) -> bool {
-    let name = path.rsplit('/').next().unwrap_or(path);
-    matches!(name, "compose.yaml" | "docker-compose.yaml")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn compose_yaml_accepted() {
-        assert!(is_compose_file("compose.yaml"));
-        assert!(is_compose_file("apps/myapp/compose.yaml"));
-    }
-
-    #[test]
-    fn docker_compose_yaml_accepted() {
-        assert!(is_compose_file("docker-compose.yaml"));
-        assert!(is_compose_file("infra/svc/docker-compose.yaml"));
-    }
-
-    #[test]
-    fn arbitrary_yaml_rejected() {
-        assert!(!is_compose_file("renovate.yaml"));
-        assert!(!is_compose_file(".renovaterc.yaml"));
-        assert!(!is_compose_file("ci.yml"));
-        assert!(!is_compose_file("not-compose.yaml"));
-    }
-
-    #[test]
-    fn yml_variants_rejected() {
-        // We intentionally do not support .yml — compose files use .yaml.
-        assert!(!is_compose_file("compose.yml"));
-        assert!(!is_compose_file("docker-compose.yml"));
-    }
-}

--- a/src/poller.rs
+++ b/src/poller.rs
@@ -185,4 +185,3 @@ impl<D: DockerExecutor> Poller<D> {
         )
     }
 }
-

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -59,11 +59,18 @@ pub fn router<D: DockerExecutor>(state: AppState<D>) -> axum::Router {
     #[cfg(feature = "metrics")]
     let (prometheus_layer, metric_handle) = PrometheusMetricLayer::pair();
 
-    let webhook_router = match state.config.mode {
-        crate::config::Mode::Webhook { .. } => axum::Router::new().route(
-            "/webhook/github",
-            post(github_webhook).layer(DefaultBodyLimit::max(1024 * 1024)),
-        ),
+    let webhook_router = match &state.config.mode {
+        crate::config::Mode::Webhook { secret } => {
+            let secret = secret.clone();
+            axum::Router::new().route(
+                "/webhook/github",
+                post(move |State(st): State<AppState<D>>, hdrs: HeaderMap, body: Bytes| {
+                    let s = secret.clone();
+                    async move { github_webhook(st, hdrs, body, s).await }
+                })
+                .layer(DefaultBodyLimit::max(1024 * 1024)),
+            )
+        }
         crate::config::Mode::Poll { .. } => axum::Router::new(),
     };
 
@@ -262,10 +269,11 @@ pub async fn list_managed_services<D: DockerExecutor>(
     Ok(Json(ManagedServicesResponse { services, total }))
 }
 
-pub async fn github_webhook<D: DockerExecutor>(
-    State(state): State<AppState<D>>,
+async fn github_webhook<D: DockerExecutor>(
+    state: AppState<D>,
     headers: HeaderMap,
     body: Bytes,
+    secret: String,
 ) -> StatusCode {
     let signature =
         match headers.get("X-Hub-Signature-256").and_then(|v| v.to_str().ok()) {
@@ -277,15 +285,7 @@ pub async fn github_webhook<D: DockerExecutor>(
             }
         };
 
-    let secret = match &state.config.mode {
-        crate::config::Mode::Webhook { secret } => secret.as_str(),
-        crate::config::Mode::Poll { .. } => {
-            tracing::error!("Webhook handler reached in polling mode");
-            return StatusCode::INTERNAL_SERVER_ERROR;
-        }
-    };
-
-    if !verify_github_signature(secret, &body, &signature) {
+    if !verify_github_signature(&secret, &body, &signature) {
         tracing::warn!("Invalid webhook signature");
         crate::metrics::webhook_received("signature_invalid");
         return StatusCode::UNAUTHORIZED;
@@ -532,34 +532,21 @@ mod tests {
         api_token: Option<&str>,
     ) -> AppState<crate::container::docker::CapturingDockerExecutor> {
         use crate::{
-            config::{Config, Mode},
-            container::docker::CapturingDockerExecutor,
+            config::Config,
+            container::{docker::CapturingDockerExecutor, github::GitHubClient},
             features,
         };
-        let config = Arc::new(Config {
-            root_dir: std::env::temp_dir().to_string_lossy().into_owned(),
-            log_level: "info".to_string(),
-            renovate_username: "renovate[bot]".to_string(),
-            renovate_email: "renovate[bot]@users.noreply.github.com".to_string(),
-            github_token: None,
-            allow_latest_images: false,
-            api_token: api_token.map(String::from),
-            mode: Mode::Webhook { secret: "test".to_string() },
-            service_filter: None,
-            repo_path_prefix: None,
-            initial_sync: true,
-            shepherd_service_name: None,
-            #[cfg(feature = "otlp")]
-            otlp_endpoint: "http://localhost:4317".to_string(),
-        });
+        let config = Arc::new(Config::for_test(api_token));
+        let github_client = Arc::new(GitHubClient::new(None));
         let flags = features::new_flags();
         let orchestrator = crate::container::DeploymentOrchestrator::with_executor(
-            &config,
+            Arc::clone(&config),
+            github_client,
             flags.clone(),
             CapturingDockerExecutor::new(),
         )
         .await
-        .expect("DeploymentOrchestrator::new failed — is docker installed?");
+        .expect("DeploymentOrchestrator::with_executor failed");
         AppState { config, orchestrator: Arc::new(orchestrator), flags }
     }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -64,10 +64,14 @@ pub fn router<D: DockerExecutor>(state: AppState<D>) -> axum::Router {
             let secret = secret.clone();
             axum::Router::new().route(
                 "/webhook/github",
-                post(move |State(st): State<AppState<D>>, hdrs: HeaderMap, body: Bytes| {
-                    let s = secret.clone();
-                    async move { github_webhook(st, hdrs, body, s).await }
-                })
+                post(
+                    move |State(st): State<AppState<D>>,
+                          hdrs: HeaderMap,
+                          body: Bytes| {
+                        let s = secret.clone();
+                        async move { github_webhook(st, hdrs, body, s).await }
+                    },
+                )
                 .layer(DefaultBodyLimit::max(1024 * 1024)),
             )
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Filesystem scanning now recognizes only canonical Compose filenames: `compose.yaml` and `docker-compose.yaml`.
  - Unrelated YAML and YML files are no longer treated as Compose files during deployment or webhook processing.
  - Webhook handling now consistently uses the configured webhook secret, improving validation reliability.
- **Improvements**
  - Deployment and repository synchronization now share configuration and GitHub connection settings consistently across background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->