### PR TITLE
fix(container): when shepherd gets updated it causes race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,9 +1215,9 @@ checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loom"

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All configuration is via environment variables. A `.env` file is loaded if prese
 | `SERVICE_FILTER` | no | — | Comma-separated names of services this instance may deploy — these are the keys under `services:` in the compose file, not folder names; unset means all |
 | `ALLOW_LATEST_IMAGES` | no | `false` | Allow services tagged `latest` to be deployed |
 | `INITIAL_SYNC` | no | `true` | On startup, pull and apply all services using idempotent `docker compose up -d --no-deps`. Catches any drift that accumulated while Shepherd was down. Set to `false` to disable. |
-| `SHEPHERD_SERVICE_NAME` | no | — | The compose service name Shepherd itself runs as. When set, Shepherd always deploys itself last in any batch so sibling services are updated before it replaces its own container. Set this to match the service key under `services:` in your compose file (e.g. `shepherd`). |
+| `SHEPHERD_SERVICE_NAME` | no | — | The compose service name Shepherd itself runs as. When set, Shepherd deploys itself last in any batch and uses a short-lived `shepherd-updater` container to perform its own update — this avoids a race where Shepherd would be killed before it could start its own replacement. Must match the service key under `services:` exactly (e.g. `shepherd`). |
 | `API_TOKEN` | no | — | Bearer token required for `/flags/*` and `/sync` endpoints |
 | `LOG_LEVEL` | no | `info` | One of `trace`, `debug`, `info`, `warn`, `error` |
 | `OTLP_ENDPOINT` | no | — | gRPC endpoint for traces; required with `--features otlp` |
@@ -70,7 +70,18 @@ services:
     environment:
       ROOT_DIR: /srv/compose
       WEBHOOK_SECRET: your-secret
+      SHEPHERD_SERVICE_NAME: shepherd
 ```
+
+### Self-updating
+
+When `SHEPHERD_SERVICE_NAME` is set, Shepherd handles its own container replacement differently. Updating itself through the normal `docker compose up` path would fail: Docker Compose stops the running container before starting the replacement, and since Shepherd is PID 1 in its container, it is killed before the start command can run — leaving the new container stuck in `Created` state.
+
+Instead, Shepherd spawns a separate `shepherd-updater` container (using its own image, which includes the Docker CLI) to run `docker compose up --force-recreate` from outside its own container namespace. The updater survives Shepherd's shutdown and completes the transition.
+
+The `shepherd-updater` container name is reserved — do not use it for any other service.
+
+On startup, Shepherd removes any leftover `shepherd-updater` container before performing the initial sync, recovering cleanly from a previous interrupted update.
 
 See `docker-compose.example.yml` for a complete example.
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -382,7 +382,9 @@ impl<D: DockerExecutor, G: ForgeProvider> DeploymentOrchestrator<D, G> {
                         Err(e) if e.to_string().contains("name already in use") => {
                             tracing::info!(
                                 service = %service.name,
-                                "Updater container is already running"
+                                "Updater container is already running \
+                                If a newer image was pushed concurrently, the next poll cycle will detect \
+                                the drift and redeploy."
                             );
                         }
                         Err(e) => {

--- a/src/container.rs
+++ b/src/container.rs
@@ -193,6 +193,11 @@ impl<D: DockerExecutor, G: ForgeProvider> DeploymentOrchestrator<D, G> {
     #[tracing::instrument(skip(self))]
     pub async fn initial_sync(&self) -> Result<()> {
         tracing::info!("Starting initial sync");
+
+        if let Err(e) = self.docker_client.cleanup_updater_container().await {
+            tracing::warn!("Failed to remove shepherd-updater container: {e:?}");
+        }
+
         let services = self.get_managed_services().await?;
         let mut queued = 0u32;
         for service in services {
@@ -344,16 +349,33 @@ impl<D: DockerExecutor, G: ForgeProvider> DeploymentOrchestrator<D, G> {
         }
 
         for service in to_restart {
-            if self
+            let is_self = self
                 .config
                 .shepherd_service_name
                 .as_deref()
-                .is_some_and(|n| n.eq_ignore_ascii_case(&service.name))
-            {
+                .is_some_and(|n| n.eq_ignore_ascii_case(&service.name));
+
+            if is_self {
                 tracing::info!(
                     service = %service.name,
-                    "Deploying self — process will exit after docker compose up returns"
+                    "Self-update detected. Spawning updater container"
                 );
+
+                if let Err(e) = self
+                    .docker_client
+                    .spawn_self_updater(
+                        &service.path,
+                        &service.name,
+                        &self.config.root_dir,
+                        &service.image,
+                    )
+                    .await
+                {
+                    tracing::error!("Failed to spawn self-updater: {e:?}");
+                }
+
+                // We don't want standard updater to race with updater child process.
+                continue;
             }
             if let Err(e) =
                 self.execute_and_record(&service, DeployMode::ForceRecreate).await
@@ -681,6 +703,20 @@ mod tests {
         async fn check_available(&self) -> bool {
             false
         }
+
+        async fn spawn_self_updater(
+            &self,
+            _compose_file: &Path,
+            _service_name: &str,
+            _root_dir: &str,
+            _image: &str,
+        ) -> Result<()> {
+            Err(eyre::eyre!("docker spawn_self_updater failed"))
+        }
+
+        async fn cleanup_updater_container(&self) -> Result<()> {
+            Err(eyre::eyre!("docker cleanup_updater_container failed"))
+        }
     }
 
     async fn fake_orchestrator() -> DeploymentOrchestrator<
@@ -879,6 +915,7 @@ mod tests {
             .filter_map(|c| match c {
                 DockerCall::RestartService { service, .. }
                 | DockerCall::ComposeUp { service, .. } => Some(service.as_str()),
+                DockerCall::SpawnSelfUpdater { service } => Some(service.as_str()),
                 _ => None,
             })
             .collect();
@@ -889,6 +926,116 @@ mod tests {
             vec!["app", "shepherd"],
             "shepherd must deploy last; got order: {:?}",
             service_names
+        );
+    }
+
+    #[tokio::test]
+    async fn initial_sync_calls_cleanup_updater_on_startup() {
+        let orchestrator = fake_orchestrator().await;
+        orchestrator.initial_sync().await.unwrap();
+
+        let recorded_calls = orchestrator.docker_client.calls();
+
+        assert!(
+            recorded_calls.iter().any(|c| matches!(c, DockerCall::CleanupUpdater)),
+            "initial sync msut call cleanup_updater_container on startup"
+        );
+
+        assert!(
+            matches!(recorded_calls.first(), Some(DockerCall::CleanupUpdater)),
+            "CleanupUpdater must be the first docker call in the initial_sync"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_push_shepherd_uses_normal_deploy_when_service_name_not_configured()
+     {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let github = Arc::new(FakeGitHubClient::default());
+        let executor = CapturingDockerExecutor::new();
+        let calls = executor.calls.clone();
+        // shepherd_service_name is None — no self-update detection
+        let config = Arc::new(crate::config::Config {
+            root_dir: tmp.path().to_string_lossy().into_owned(),
+            shepherd_service_name: None,
+            ..crate::config::Config::for_test(None)
+        });
+        let orchestrator = DeploymentOrchestrator::with_executor(
+            Arc::clone(&config),
+            Arc::clone(&github),
+            features::new_flags(),
+            executor,
+        )
+        .await
+        .unwrap();
+
+        let yaml = "services:\n  shepherd:\n    image: shepherd:2.0\n";
+        github
+            .file_content
+            .lock()
+            .unwrap()
+            .insert("compose.yaml".to_string(), yaml.to_string());
+
+        let payload = push_payload(
+            "refs/heads/main",
+            "main",
+            vec![renovate_commit(vec!["compose.yaml"])],
+        );
+        orchestrator.handle_webhook(&payload).await.unwrap();
+
+        let recorded_calls = calls.lock().unwrap();
+        let has_self_updater = recorded_calls
+            .iter()
+            .any(|c| matches!(c, DockerCall::SpawnSelfUpdater { .. }));
+        let has_restart = recorded_calls
+            .iter()
+            .any(|c| matches!(c, DockerCall::RestartService { .. }));
+
+        assert!(
+            !has_self_updater,
+            "SpawnSelfUpdater must not be called when shepherd_service_name is None"
+        );
+        assert!(
+            has_restart,
+            "shepherd must go through normal RestartService when service name not configured"
+        );
+    }
+
+    #[tokio::test]
+    async fn process_push_self_update_failure_does_not_abort() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let github = Arc::new(FakeGitHubClient::default());
+        let config = Arc::new(crate::config::Config {
+            root_dir: tmp.path().to_string_lossy().into_owned(),
+            shepherd_service_name: Some("shepherd".to_string()),
+            ..crate::config::Config::for_test(None)
+        });
+        let orch = DeploymentOrchestrator::with_executor(
+            Arc::clone(&config),
+            Arc::clone(&github),
+            features::new_flags(),
+            FailingDockerExecutor,
+        )
+        .await
+        .unwrap();
+
+        let yaml = "services:\n  app:\n    image: myapp:1.0\n  shepherd:\n    image: shepherd:2.0\n";
+        github
+            .file_content
+            .lock()
+            .unwrap()
+            .insert("compose.yaml".to_string(), yaml.to_string());
+
+        let payload = push_payload(
+            "refs/heads/main",
+            "main",
+            vec![renovate_commit(vec!["compose.yaml"])],
+        );
+
+        let result = orch.handle_webhook(&payload).await;
+        assert!(
+            result.is_ok(),
+            "process_push must return Ok even when spawn_self_updater fails"
         );
     }
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -382,9 +382,10 @@ impl<D: DockerExecutor, G: ForgeProvider> DeploymentOrchestrator<D, G> {
                         Err(e) if e.to_string().contains("name already in use") => {
                             tracing::info!(
                                 service = %service.name,
-                                "Updater container is already running \
+                                "Updater container is already running - a concurrent self-update is in progress \
                                 If a newer image was pushed concurrently, the next poll cycle will detect \
-                                the drift and redeploy."
+                                the drift and redeploy. If shepherd is in webhook mode and a newer image is pushed \
+                                concurrently, that version may not be picked up automatically."
                             );
                         }
                         Err(e) => {

--- a/src/container.rs
+++ b/src/container.rs
@@ -194,7 +194,9 @@ impl<D: DockerExecutor, G: ForgeProvider> DeploymentOrchestrator<D, G> {
     pub async fn initial_sync(&self) -> Result<()> {
         tracing::info!("Starting initial sync");
 
-        if let Err(e) = self.docker_client.cleanup_updater_container().await {
+        if !self.flags.load().dry_run
+            && let Err(e) = self.docker_client.cleanup_updater_container().await
+        {
             tracing::warn!("Failed to remove shepherd-updater container: {e:?}");
         }
 
@@ -360,18 +362,33 @@ impl<D: DockerExecutor, G: ForgeProvider> DeploymentOrchestrator<D, G> {
                     service = %service.name,
                     "Self-update detected. Spawning updater container"
                 );
-
-                if let Err(e) = self
-                    .docker_client
-                    .spawn_self_updater(
-                        &service.path,
-                        &service.name,
-                        &self.config.root_dir,
-                        &service.image,
-                    )
-                    .await
-                {
-                    tracing::error!("Failed to spawn self-updater: {e:?}");
+                if self.flags.load().dry_run {
+                    tracing::info!(
+                        service = %service.name,
+                        "[dry-run] would spawn shepherd-updater container"
+                    );
+                } else {
+                    match self
+                        .docker_client
+                        .spawn_self_updater(
+                            &service.path,
+                            &service.name,
+                            &self.config.root_dir,
+                            &service.image,
+                        )
+                        .await
+                    {
+                        Ok(()) => {}
+                        Err(e) if e.to_string().contains("name already in use") => {
+                            tracing::info!(
+                                service = %service.name,
+                                "Updater container is already running"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to spawn self-updater {e:?}");
+                        }
+                    }
                 }
 
                 // We don't want standard updater to race with updater child process.

--- a/src/container/docker.rs
+++ b/src/container/docker.rs
@@ -182,9 +182,8 @@ impl DockerClient {
         image: &str,
     ) -> Result<()> {
         let compose_path = compose_file.to_string_lossy();
-        let cmd = format!(
-            "docker compose -f {compose_path} up -d --force-recreate --no-deps {service_name}"
-        );
+        let cmd =
+            "exec docker compose -f \"$1\" up -d --force-recreate --no-deps \"$2\"";
         let root_vol = format!("{root_dir}:{root_dir}");
 
         let args = vec![
@@ -198,7 +197,10 @@ impl DockerClient {
             "sh",
             image,
             "-c",
-            &cmd,
+            cmd,
+            "shepherd-updater",
+            &compose_path,
+            service_name,
         ];
         let child = TokioCommand::new(&self.docker_bin)
             .args(["run", "--rm", "-d"])
@@ -233,7 +235,7 @@ impl DockerClient {
             .spawn()
             .wrap_err("Failed to spawn docker rm for shepherd-updater")?;
 
-        let _ = child.wait_with_output().await;
+        let _ = timeout(DOCKER_COMMAND_TIMEOUT, child.wait_with_output()).await;
         Ok(())
     }
 }

--- a/src/container/docker.rs
+++ b/src/container/docker.rs
@@ -29,6 +29,16 @@ pub trait DockerExecutor: Clone + Send + Sync + 'static {
     ) -> impl Future<Output = Result<()>> + Send;
 
     fn check_available(&self) -> impl Future<Output = bool> + Send;
+
+    fn spawn_self_updater(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+        root_dir: &str,
+        image: &str,
+    ) -> impl Future<Output = Result<()>> + Send;
+
+    fn cleanup_updater_container(&self) -> impl Future<Output = Result<()>> + Send;
 }
 
 #[derive(Clone)]
@@ -163,6 +173,69 @@ impl DockerClient {
 
         Ok(())
     }
+
+    async fn run_self_updater(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+        root_dir: &str,
+        image: &str,
+    ) -> Result<()> {
+        let compose_path = compose_file.to_string_lossy();
+        let cmd = format!(
+            "docker compose -f {compose_path} up -d --force-recreate --no-deps {service_name}"
+        );
+        let root_vol = format!("{root_dir}:{root_dir}");
+
+        let args = vec![
+            "--name",
+            "shepherd-updater",
+            "-v",
+            "/var/run/docker.sock:/var/run/docker.sock",
+            "-v",
+            &root_vol,
+            "--entrypoint",
+            "sh",
+            image,
+            "-c",
+            &cmd,
+        ];
+        let child = TokioCommand::new(&self.docker_bin)
+            .args(["run", "--rm", "-d"])
+            .args(&args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .wrap_err("Failed to spawn shepherd-updater container")?;
+
+        let output = timeout(DOCKER_COMMAND_TIMEOUT, child.wait_with_output())
+            .await
+            .map_err(|_| eyre!("docker run shepherd-updater timed out"))?
+            .wrap_err("Failed to execute docker run for shepherd-updater")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(eyre!(
+                "Failed to start shepherd-updater container: {stderr}"
+            ));
+        }
+
+        Ok(())
+    }
+
+    async fn remove_updater_container(&self) -> Result<()> {
+        let child = TokioCommand::new(&self.docker_bin)
+            .args(["rm", "-f", "shepherd-updater"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .wrap_err("Failed to spawn docker rm for shepherd-updater")?;
+
+        let _ = child.wait_with_output().await;
+        Ok(())
+    }
 }
 
 impl DockerExecutor for DockerClient {
@@ -189,6 +262,20 @@ impl DockerExecutor for DockerClient {
     async fn check_available(&self) -> bool {
         Self::verify_compose_available(&self.docker_bin).await.is_ok()
     }
+
+    async fn spawn_self_updater(
+        &self,
+        compose_file: &Path,
+        service_name: &str,
+        root_dir: &str,
+        image: &str,
+    ) -> Result<()> {
+        self.run_self_updater(compose_file, service_name, root_dir, image).await
+    }
+
+    async fn cleanup_updater_container(&self) -> Result<()> {
+        self.remove_updater_container().await
+    }
 }
 
 #[cfg(test)]
@@ -198,6 +285,8 @@ pub enum DockerCall {
     PullImage(String),
     RestartService { path: std::path::PathBuf, service: String },
     ComposeUp { path: std::path::PathBuf, service: String },
+    SpawnSelfUpdater { service: String },
+    CleanupUpdater,
 }
 
 #[cfg(test)]
@@ -253,6 +342,25 @@ impl DockerExecutor for CapturingDockerExecutor {
 
     async fn check_available(&self) -> bool {
         true
+    }
+
+    async fn spawn_self_updater(
+        &self,
+        _compose_file: &Path,
+        service_name: &str,
+        _root_dir: &str,
+        _image: &str,
+    ) -> Result<()> {
+        self.calls.lock().unwrap().push(DockerCall::SpawnSelfUpdater {
+            service: service_name.to_string(),
+        });
+
+        Ok(())
+    }
+
+    async fn cleanup_updater_container(&self) -> Result<()> {
+        self.calls.lock().unwrap().push(DockerCall::CleanupUpdater);
+        Ok(())
     }
 }
 

--- a/src/container/docker.rs
+++ b/src/container/docker.rs
@@ -230,22 +230,30 @@ impl DockerClient {
         let child = TokioCommand::new(&self.docker_bin)
             .args(["rm", "-f", "shepherd-updater"])
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
+            .stderr(Stdio::piped())
             .kill_on_drop(true)
             .spawn()
             .wrap_err("Failed to spawn docker rm for shepherd-updater")?;
 
-        // We don't care what timeout returns in this case. We just want to know that
-        // command's timed out
-        #[allow(unused)]
-        timeout(DOCKER_COMMAND_TIMEOUT, child.wait_with_output()).await.map_err(
-            |_| {
+        let output = timeout(DOCKER_COMMAND_TIMEOUT, child.wait_with_output())
+            .await
+            .map_err(|_| {
                 eyre!(
                     "docker rm shepherd-updater timed out after {}s",
                     DOCKER_COMMAND_TIMEOUT.as_secs()
                 )
-            },
-        )?;
+            })?
+            .wrap_err("Failed to execute docker rm for shepherd-updater")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            // No container to remove is the expected case on a clean startup.
+            if stderr.contains("No such container") {
+                return Ok(());
+            }
+            return Err(eyre!("docker rm shepherd-updater failed: {stderr}"));
+        }
+
         Ok(())
     }
 }

--- a/src/container/docker.rs
+++ b/src/container/docker.rs
@@ -235,7 +235,17 @@ impl DockerClient {
             .spawn()
             .wrap_err("Failed to spawn docker rm for shepherd-updater")?;
 
-        let _ = timeout(DOCKER_COMMAND_TIMEOUT, child.wait_with_output()).await;
+        // We don't care what timeout returns in this case. We just want to know that
+        // command's timed out
+        #[allow(unused)]
+        timeout(DOCKER_COMMAND_TIMEOUT, child.wait_with_output()).await.map_err(
+            |_| {
+                eyre!(
+                    "docker rm shepherd-updater timed out after {}s",
+                    DOCKER_COMMAND_TIMEOUT.as_secs()
+                )
+            },
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic self-updating for webhook-triggered deployments using a temporary updater container.
  * Self-updates now run independently of regular deployment processing.
  * Added startup cleanup for leftover updater containers.

* **Bug Fixes**
  * Dry-run operations no longer remove updater containers or start self-update containers.
  * Concurrent updates are handled without treating an already-running updater as a failure.
  * Improved timeout handling for updater cleanup and non-fatal handling of other updater launch failures.

* **Documentation**
  * Expanded self-update setup, configuration, container naming, and replacement behavior guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->